### PR TITLE
there's a problem when one of the dates is blank

### DIFF
--- a/lib/has_calendar.rb
+++ b/lib/has_calendar.rb
@@ -36,11 +36,13 @@ module SimplesIdeias
         # group all records if data is provided
         if options[:events]
           records = options[:events].inject({}) do |memo, record|
-            stamp = record.send(options[:field]).to_date.to_s(:number)
-            memo[stamp] ||= []
-            memo[stamp] << record
-            memo
-          end
+            unless record.send(options[:field]).nil?
+              stamp = record.send(options[:field]).to_date.to_s(:number)
+              memo[stamp] ||= []
+              memo[stamp] << record
+            end  
+	    memo
+	  end
         end
       
         # building the calendar


### PR DESCRIPTION
I used custom :events and :field values and one of those :field dates was blank, so it caused an error on building calendar - I've added a check for this case.
